### PR TITLE
Updated to 0.7.1.4. Added possibility to autocategorize by the Wilson Score.

### DIFF
--- a/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.Designer.cs
+++ b/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.Designer.cs
@@ -47,6 +47,8 @@
             this.helpPrefix = new System.Windows.Forms.Label();
             this.lblPrefix = new System.Windows.Forms.Label();
             this.txtPrefix = new System.Windows.Forms.TextBox();
+            this.helpUseWilsonScore = new System.Windows.Forms.Label();
+            this.chkUseWilsonScore = new System.Windows.Forms.CheckBox();
             this.ttHelp = new Depressurizer.Lib.ExtToolTip();
             this.grpMain.SuspendLayout();
             this.groupPresets.SuspendLayout();
@@ -64,6 +66,8 @@
             this.grpMain.Controls.Add(this.helpPrefix);
             this.grpMain.Controls.Add(this.lblPrefix);
             this.grpMain.Controls.Add(this.txtPrefix);
+            this.grpMain.Controls.Add(this.helpUseWilsonScore);
+            this.grpMain.Controls.Add(this.chkUseWilsonScore);
             this.grpMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.grpMain.Location = new System.Drawing.Point(0, 0);
             this.grpMain.Name = "grpMain";
@@ -327,6 +331,26 @@
             this.txtPrefix.Size = new System.Drawing.Size(165, 20);
             this.txtPrefix.TabIndex = 1;
             // 
+            // helpUseWilsonScore
+            // 
+            this.helpUseWilsonScore.AutoSize = true;
+            this.helpUseWilsonScore.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.helpUseWilsonScore.Location = new System.Drawing.Point(391, 22);
+            this.helpUseWilsonScore.Name = "helpUseWilsonScore";
+            this.helpUseWilsonScore.Size = new System.Drawing.Size(15, 15);
+            this.helpUseWilsonScore.TabIndex = 7;
+            this.helpUseWilsonScore.Text = "?";
+            // 
+            // chkUseWilsonScore
+            // 
+            this.chkUseWilsonScore.AutoSize = true;
+            this.chkUseWilsonScore.Location = new System.Drawing.Point(274, 21);
+            this.chkUseWilsonScore.Name = "chkUseWilsonScore";
+            this.chkUseWilsonScore.Size = new System.Drawing.Size(111, 17);
+            this.chkUseWilsonScore.TabIndex = 6;
+            this.chkUseWilsonScore.Text = "Use Wilson Score";
+            this.chkUseWilsonScore.UseVisualStyleBackColor = true;
+            // 
             // AutoCatConfigPanel_UserScore
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -354,6 +378,8 @@
         private System.Windows.Forms.Label helpPrefix;
         private System.Windows.Forms.Label lblPrefix;
         private System.Windows.Forms.TextBox txtPrefix;
+        private System.Windows.Forms.Label helpUseWilsonScore;
+        private System.Windows.Forms.CheckBox chkUseWilsonScore;
         private System.Windows.Forms.GroupBox grpRules;
         private System.Windows.Forms.Button cmdRuleDown;
         private System.Windows.Forms.Button cmdRuleUp;

--- a/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.cs
+++ b/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.cs
@@ -35,6 +35,7 @@ namespace Depressurizer {
 
             // Set up help tooltips
             ttHelp.Ext_SetToolTip( helpPrefix, GlobalStrings.DlgAutoCat_Help_Prefix );
+            ttHelp.Ext_SetToolTip( helpUseWilsonScore, GlobalStrings.DlgAutoCat_Help_UseWilsonScore );
             ttHelp.Ext_SetToolTip( helpRules, GlobalStrings.AutoCatUserScore_Help_Rules );
 
             // Set up bindings.
@@ -66,6 +67,7 @@ namespace Depressurizer {
             if( ac == null ) return;
 
             acScore.Prefix = txtPrefix.Text;
+            acScore.UseWilsonScore = chkUseWilsonScore.Checked;
             acScore.Rules = new List<UserScore_Rule>( ruleList );
         }
 
@@ -74,6 +76,7 @@ namespace Depressurizer {
             if( ac == null ) return;
 
             txtPrefix.Text = acScore.Prefix;
+            chkUseWilsonScore.Checked = acScore.UseWilsonScore;
 
             ruleList.Clear();
             foreach( UserScore_Rule rule in acScore.Rules ) {

--- a/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.resx
+++ b/Depressurizer/AutoCat/AutoCatConfigPanel_UserScore.resx
@@ -120,4 +120,7 @@
   <metadata name="ttHelp.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>68</value>
+  </metadata>
 </root>

--- a/Depressurizer/Depressurizer.csproj
+++ b/Depressurizer/Depressurizer.csproj
@@ -615,7 +615,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="depressurizer_icon.ico" />
-    <Content Include="prgm2.ico" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Depressurizer/GlobalStrings.Designer.cs
+++ b/Depressurizer/GlobalStrings.Designer.cs
@@ -1136,6 +1136,18 @@ namespace Depressurizer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use the lower bound of the Wilson 95% confidence interval instead of the positive reviews fraction.
+        ///There would be 95% confidence that the “real” positive fraction is at least the score calculated.
+        ///This calculation reduces the rating if the number of reviews is too low.
+        ///See: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html.
+        /// </summary>
+        internal static string DlgAutoCat_Help_UseWilsonScore {
+            get {
+                return ResourceManager.GetString("DlgAutoCat_Help_UseWilsonScore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to AutoCat must have a name..
         /// </summary>
         internal static string DlgAutoCat_MustHaveName {

--- a/Depressurizer/GlobalStrings.resx
+++ b/Depressurizer/GlobalStrings.resx
@@ -1344,4 +1344,10 @@ Close Steam BEFORE restoring!</value>
   <data name="DlgRestore_ProfileConfirm" xml:space="preserve">
     <value>Are you sure you want to overwrite your profile with: {0}?</value>
   </data>
+  <data name="DlgAutoCat_Help_UseWilsonScore" xml:space="preserve">
+    <value>Use the lower bound of the Wilson 95% confidence interval instead of the positive reviews fraction.
+There would be 95% confidence that the “real” positive fraction is at least the score calculated.
+This calculation reduces the rating if the number of reviews is too low.
+See: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html</value>
+  </data>
 </root>

--- a/Depressurizer/Properties/AssemblyInfo.cs
+++ b/Depressurizer/Properties/AssemblyInfo.cs
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle( "Depressurizer" )]
-[assembly: AssemblyDescription( "" )]
+[assembly: AssemblyDescription("Steam Category Tool")]
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "" )]
 [assembly: AssemblyProduct( "Depressurizer" )]
-[assembly: AssemblyCopyright("Copyright © 2011-2016")]
+[assembly: AssemblyCopyright("Copyright © 2011–2016")]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -50,5 +50,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.3")]
-[assembly: AssemblyFileVersion("0.7.1.3")]
+[assembly: AssemblyVersion("0.7.1.4")]
+[assembly: AssemblyFileVersion("0.7.1.4")]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Depressurizer
-for v0.7.1.3
+for v0.7.1.4
 
 ----
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 Depressurizer
-for v0.7.1.3
+for v0.7.1.4
 
 SUMMARY
 


### PR DESCRIPTION
Updated to version 0.7.1.4.
Added the check-box to use the Wilson Score in the AutoCat by User Score.
If checked then auto categorizing by User Score will use the lower bound
of the Wilson 95% confidence interval instead of the positive reviews fraction.
There would be 95% confidence that the “real” positive fraction is at
least the score calculated.
This calculation reduces the rating if the number of reviews is too low.
See: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html
